### PR TITLE
Fix `let ... and ... in ...` syntax

### DIFF
--- a/src/eval.ml
+++ b/src/eval.ml
@@ -60,9 +60,12 @@ let rec eval_exp env = function
         BoolV true  -> eval_exp env exp2
       | BoolV false -> eval_exp env exp3
       | _ -> err ("Test expression must be boolean: if"))
-  | LetExp (x, exp, body) ->
-      let v = eval_exp env exp in
-      let newenv = Environment.extend x v env in
+  | LetExp (binds, body) ->
+      let current_env = env in
+      let newenv = fold_left (fun env' (x, exp) ->
+          let v = eval_exp current_env exp in
+          Environment.extend x v env')
+          current_env binds in
       eval_exp newenv body
   | LetRecExp (id, para, exp1, exp2) ->
       let dummyenv = ref Environment.empty in

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -89,7 +89,7 @@ IfExpr :
     IF Expr THEN Expr ELSE Expr { IfExp ($2, $4, $6) }
 
 LetExpr :
-  LET Binding IN Expr { fold_let $2 $4 }
+  LET Binding IN Expr { LetExp ($2, $4) }
 
 LetRecExpr :
     LET REC ID EQ FUN ID RARROW Expr IN Expr {

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -15,8 +15,6 @@ let fold_args args body =
 let fold_argsd args body =
   fold_right (fun x body -> DFunExp (x, body)) body args
 
-let fold_let bind body =
-  fold_right (fun (x,v) body -> LetExp (x, v, body)) body bind
 %}
 %token LPAREN RPAREN SEMISEMI
 %token PLUS MINUS MULT LT ANDAND OROR EQ

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -13,7 +13,7 @@ type exp =
   | BinOp of binOp * exp * exp
   | UniOp of uniOp * exp
   | IfExp of exp * exp * exp
-  | LetExp of id * exp * exp
+  | LetExp of (id * exp) list  * exp
   | LetRecExp of id * id * exp * exp
   | FunExp of id * exp
   | DFunExp of id * exp


### PR DESCRIPTION
Problem: The following expression should result in 110, but current implementation returns 200.

```
let x = 10 in
let x = 100
and y = x in
x + y
```

Solution: Change the tree structure of `LetExp`, update the parser, and evaluate right hand side expressions in correct environments.